### PR TITLE
11 feat api setting(2)

### DIFF
--- a/src/Apis/Category/Category.type.ts
+++ b/src/Apis/Category/Category.type.ts
@@ -1,6 +1,6 @@
 export type GetCategories = {
   id: number;
   name: string;
-  createdAt: string; // iso문자열로?
-  updatedAt: string; // iso문자열로?
+  createdAt: Date;
+  updatedAt: Date;
 };

--- a/src/Apis/Image/Image.service.ts
+++ b/src/Apis/Image/Image.service.ts
@@ -1,0 +1,22 @@
+/* eslint-disable class-methods-use-this */
+import { PostImagePayload } from './Image.type';
+import { apiFileRequestor, apiRequestorNoBaseUrl, apiRequestorToken } from '../requestor';
+
+import { removeQueryParams } from '../Utils';
+
+class ImageService {
+  postImage(payload: PostImagePayload) {
+    return apiRequestorToken.post('/images/upload', payload);
+  }
+
+  putImage(file: File, presignedUrl: string) {
+    return apiFileRequestor.put(presignedUrl, file);
+  }
+
+  getImage(presignedUrl: string) {
+    const cleanUrl = removeQueryParams(presignedUrl); // query params 제거
+    return apiRequestorNoBaseUrl.put(cleanUrl);
+  }
+}
+
+export default new ImageService();

--- a/src/Apis/Image/Image.type.ts
+++ b/src/Apis/Image/Image.type.ts
@@ -1,0 +1,7 @@
+export type PostImagePayload = {
+  image: string;
+};
+
+export type PostImageRes = {
+  url: string;
+};

--- a/src/Apis/Image/queries.ts
+++ b/src/Apis/Image/queries.ts
@@ -1,0 +1,26 @@
+import ImageService from './Image.service';
+import { PostImagePayload } from './Image.type';
+
+const queryKeys = {
+  postImage: (image: string) => ['postImage', image] as const,
+  putImage: (file: File | null) => ['putImage', { file }] as const,
+  getImage: (presignedUrl: string) => ['getImage', presignedUrl] as const,
+};
+
+const queryOptions = {
+  postImage: (image: string) => ({
+    mutationKey: queryKeys.postImage(image),
+    mutationFn: (postData: PostImagePayload) => ImageService.postImage(postData),
+  }),
+  putImage: (file: File | null) => ({
+    mutationKey: queryKeys.putImage(file),
+    mutationFn: ({ putFile, putPresignedUrl }: { putFile: File; putPresignedUrl: string }) =>
+      ImageService.putImage(putFile, putPresignedUrl),
+  }),
+  getImage: (presignedUrl: string) => ({
+    queryKey: queryKeys.getImage(presignedUrl),
+    queryFn: () => ImageService.getImage(presignedUrl),
+  }),
+};
+
+export default queryOptions;

--- a/src/Apis/Image/useImageService.ts
+++ b/src/Apis/Image/useImageService.ts
@@ -1,0 +1,36 @@
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+
+import { PostImageRes, PostImagePayload } from './Image.type';
+import queryOptions from './queries';
+import { selectData } from '../Utils';
+
+/**
+ * Presigned URL을 생성합니다.
+ * @param image required; \{
+  image: string;
+}
+ */
+
+export function usePostImage({ image }: PostImagePayload) {
+  const res = useMutation(queryOptions.postImage(image));
+  return selectData<PostImageRes>(res);
+}
+
+/**
+ * S3로 이미지를 업로드합니다.
+ * @param file required; File
+ * @param presignedUrl required; string
+ * @returns  */
+
+export function usePutImage(file: File | null) {
+  return useMutation(queryOptions.putImage(file));
+}
+
+/**
+ * Presigned URL을 조회합니다.
+ * @param presignedUrl required; string
+ * @returns  */
+
+export function useGetImage(presignedUrl: string) {
+  return useSuspenseQuery(queryOptions.getImage(presignedUrl));
+}

--- a/src/Apis/Product/Product.service.ts
+++ b/src/Apis/Product/Product.service.ts
@@ -1,0 +1,46 @@
+/* eslint-disable class-methods-use-this */
+
+import { AxiosRequestConfig } from 'axios';
+import { apiRequestor, apiRequestorToken } from '../requestor';
+import { GetProductProps, GetProductReviewList, PostProductItems } from './Product.type';
+
+class ProductService {
+  // 상품 목록 조회
+  getProductItems(params: GetProductProps) {
+    const config: AxiosRequestConfig = { params };
+    return apiRequestor.get(`/products`, config);
+  }
+
+  // 상품 생성(토큰)
+  postProductItems(payload: PostProductItems) {
+    return apiRequestorToken.post(`/products`, payload);
+  }
+
+  // 상품 상세 조회
+  getProductDetail(productId: number) {
+    return apiRequestor.get(`/products/${productId}`);
+  }
+
+  // 상품 수정
+  patchProductModify(productId: number) {
+    return apiRequestorToken.patch(`/products/${productId}`);
+  }
+
+  // 상품 리뷰 목록 조회
+  getProductReviewList(productId: number, params: GetProductReviewList) {
+    const config: AxiosRequestConfig = { params };
+    return apiRequestor.get(`/products/${productId}/reviews`, config);
+  }
+
+  // 상품 찜하기(토큰)
+  postProductFavorite(productId: number) {
+    return apiRequestorToken.post(`/products/${productId}/favorite`);
+  }
+
+  // 상품 찜하기 취소(토큰)
+  deleteProductFavorite(productId: number) {
+    return apiRequestor.delete(`/products/${productId}/favorite`);
+  }
+}
+
+export default new ProductService();

--- a/src/Apis/Product/Product.type.ts
+++ b/src/Apis/Product/Product.type.ts
@@ -1,0 +1,106 @@
+import { BaseQuery } from '../common.type';
+
+export type OrderType = 'recent' | 'rating' | 'reviewCount' | 'ratingDesc' | 'ratingAsc' | 'likeCount';
+
+export type GetProductProps = BaseQuery & {
+  keyword?: string;
+  category?: number;
+  order?: OrderType;
+  cursor?: number;
+};
+
+export type ProductItems = {
+  id: number;
+  name: string;
+  image?: string;
+  rating: number;
+  reviewCount: number;
+  categoryId: number;
+  createdAt: Date;
+  updatedAt: Date;
+  writerId: number;
+  favoriteCount: number;
+};
+
+export type ProductId = {
+  productId: number;
+};
+
+export type PostProductItems = {
+  categoryId: number;
+  image?: string;
+  description: string;
+  name: string;
+};
+
+export type GetProductReviewList = {
+  order?: OrderType;
+  cursor?: number;
+};
+
+export type CategoryMetric = {
+  reviewCount: number;
+  favoriteCount: number;
+  rating: number;
+};
+
+export type Category = {
+  name: string;
+  id: number;
+};
+
+export type GetProductItemsRes = {
+  nextCursor: number;
+  list: ProductItems[];
+};
+
+export type PostProductItemsRes = ProductItems & {
+  categoryMetric: CategoryMetric;
+  category: Category;
+  isFavorite: boolean;
+  description: string;
+};
+
+export type ProductDetailRes = ProductItems & {
+  description: string;
+  isFavorite: boolean;
+  category: Category;
+  categoryMetric: CategoryMetric;
+};
+
+export type ReviewImage = {
+  source: string;
+  id: number;
+};
+
+export type ReviewUser = {
+  image: string;
+  nickname: string;
+  id: number;
+};
+
+export type Review = {
+  user: ReviewUser;
+  reviewImages: ReviewImage[];
+  productId: number;
+  userId: number;
+  updatedAt: string;
+  createdAt: string;
+  isLiked: boolean;
+  likeCount: number;
+  content: string;
+  rating: number;
+  id: number;
+};
+
+export type GetProductReviewListRes = {
+  nextCursor: number;
+  list: Review[];
+};
+
+export type ProductFavoriteRes = ProductItems & {
+  categoryMetric: CategoryMetric;
+  category: Category;
+  isFavorite: boolean;
+  description: string;
+};

--- a/src/Apis/Product/queries.ts
+++ b/src/Apis/Product/queries.ts
@@ -1,0 +1,47 @@
+import { BaseQuery } from '../common.type';
+import ProductService from './Product.service';
+import { GetProductProps, GetProductReviewList, PostProductItems } from './Product.type';
+
+const queryKeys = {
+  getProductItems: (params: GetProductProps) => ['getProductItems', params] as const,
+  postProductItems: (payload: PostProductItems) => ['postProductItems', payload] as const,
+  getProductDetail: (productId: number) => ['getProductDetail', productId] as const,
+  patchProductModify: (productId: number) => ['patchProductModify', productId] as const,
+  getProductReviewList: (productId: number, params: GetProductReviewList) =>
+    ['getProductReviewList', { productId, params }] as const,
+  postProductFavorite: (productId: number) => ['postProductFavorite', productId] as const,
+  deleteProductFavorite: (productId: number) => ['deleteProductFavorite', productId] as const,
+};
+
+const queryOptions = {
+  getProductItems: (params: BaseQuery) => ({
+    queryKey: queryKeys.getProductItems(params),
+    queryFn: () => ProductService.getProductItems(params),
+  }),
+  postProductItems: (payload: PostProductItems) => ({
+    mutationKey: queryKeys.postProductItems(payload),
+    mutationFn: (patchPayload: PostProductItems) => ProductService.postProductItems(patchPayload),
+  }),
+  getProductDetail: (productId: number) => ({
+    queryKey: queryKeys.getProductDetail(productId),
+    queryFn: () => ProductService.getProductDetail(productId),
+  }),
+  patchProductModify: (productId: number) => ({
+    mutationKey: queryKeys.patchProductModify(productId),
+    mutationFn: () => ProductService.patchProductModify(productId),
+  }),
+  getProductReviewList: (productId: number, params: GetProductReviewList) => ({
+    queryKey: queryKeys.getProductReviewList(productId, params),
+    queryFn: () => ProductService.getProductReviewList(productId, params),
+  }),
+  postProductFavorite: (productId: number) => ({
+    mutationKey: queryKeys.postProductFavorite(productId),
+    mutationFn: () => ProductService.postProductFavorite(productId),
+  }),
+  deleteProductFavorite: (productId: number) => ({
+    mutationKey: queryKeys.deleteProductFavorite(productId),
+    mutationFn: () => ProductService.deleteProductFavorite(productId),
+  }),
+};
+
+export default queryOptions;

--- a/src/Apis/Product/useProduct.Service.ts
+++ b/src/Apis/Product/useProduct.Service.ts
@@ -1,0 +1,92 @@
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import queryOptions from './queries';
+import { selectData } from '../Utils';
+import {
+  GetProductItemsRes,
+  GetProductProps,
+  GetProductReviewList,
+  GetProductReviewListRes,
+  PostProductItems,
+  PostProductItemsRes,
+  ProductDetailRes,
+  ProductFavoriteRes,
+} from './Product.type';
+
+/**
+ * 상품 목록 조회
+ * @param params optional; \{
+  offset?: number;
+  limit?: number;
+  keyword?: string;
+  category?: number;
+  order?: 'recent' | 'rating' | 'reviewCount';
+  cursor?: number;
+}
+ */
+export function useGetProductItems(params: GetProductProps) {
+  const res = useSuspenseQuery(queryOptions.getProductItems(params));
+  return selectData<GetProductItemsRes>(res);
+}
+
+/**
+ * 상품 생성
+ * @param payload required; {
+  categoryId: number;
+  image: null | string;
+  description: string;
+  name: string;
+}
+ */
+export function usePostProductItems(payload: PostProductItems) {
+  const res = useMutation(queryOptions.postProductItems(payload));
+  return selectData<PostProductItemsRes>(res);
+}
+
+/**
+ * 상품 상세 조회
+ * @param productId require number;
+ */
+export function useGetProductDetail(productId: number) {
+  const res = useSuspenseQuery(queryOptions.getProductDetail(productId));
+  return selectData<ProductDetailRes>(res);
+}
+
+/**
+ * 상품 수정
+ * @param productId require number;
+ */
+export function usePatchProductModify(productId: number) {
+  const res = useMutation(queryOptions.patchProductModify(productId));
+  return selectData<ProductDetailRes>(res);
+}
+
+/**
+ * 상품 리뷰 목록 조회
+ * @param productId require number;
+ * @param params optional; \{
+  order?: 'recent' | 'ratingDesc' | 'ratingAsc' | 'likeCount';
+  cursor?: number;
+}
+ */
+export function useGetProductReviewList(productId: number, params: GetProductReviewList) {
+  const res = useSuspenseQuery(queryOptions.getProductReviewList(productId, params));
+  return selectData<GetProductReviewListRes>(res);
+}
+
+/**
+ * 상품 찜하기
+ * @param productId require number;
+ */
+export function usePostProductFavorite(productId: number) {
+  const res = useMutation(queryOptions.postProductFavorite(productId));
+  return selectData<ProductFavoriteRes>(res);
+}
+
+/**
+ * 유저가 찜한 상품 조회
+ * @param productId require number;
+ */
+export function useDeleteProductFavorite(productId: number) {
+  const res = useMutation(queryOptions.deleteProductFavorite(productId));
+  return selectData<ProductFavoriteRes>(res);
+}

--- a/src/Apis/Review/Review.service.ts
+++ b/src/Apis/Review/Review.service.ts
@@ -1,0 +1,36 @@
+/* eslint-disable class-methods-use-this */
+
+import { AxiosRequestConfig } from 'axios';
+import { apiRequestorToken } from '../requestor';
+import { PatchReview, PostReview } from './Review.type';
+
+class ReviewService {
+  // 리뷰 생성
+  postReview(params: PostReview) {
+    const config: AxiosRequestConfig = { params };
+    return apiRequestorToken.post(`/reviews`, config);
+  }
+
+  // 리뷰 삭제
+  deleteReview(reviewId: number) {
+    return apiRequestorToken.delete(`/reviews/${reviewId}`);
+  }
+
+  // 리뷰 좋아요
+  postReviewLike(reviewId: number) {
+    return apiRequestorToken.post(`/products/${reviewId}/like`);
+  }
+
+  // 리뷰 좋아요 취소
+  deleteReviewLike(reviewId: number) {
+    return apiRequestorToken.delete(`reviews/${reviewId}/like`);
+  }
+
+  // 리뷰 수정
+  patchReview(reviewId: number, params: PatchReview) {
+    const config: AxiosRequestConfig = { params };
+    return apiRequestorToken.patch(`reviews/${reviewId}`, config);
+  }
+}
+
+export default new ReviewService();

--- a/src/Apis/Review/Review.type.ts
+++ b/src/Apis/Review/Review.type.ts
@@ -1,0 +1,47 @@
+export type Image = {
+  source: string;
+  id: number;
+};
+
+export type User = {
+  image: string;
+  nickname: string;
+  id: number;
+};
+
+export type ReviewBase = {
+  productId: number;
+  userId: number;
+  updatedAt: string;
+  createdAt: string;
+  likeCount: number;
+  content: string;
+  rating: number;
+  id: number;
+};
+
+export type PostReview = {
+  productId: number;
+  images: string[];
+  content: string;
+  rating: number;
+};
+
+export type PatchReview = {
+  images: Image[];
+  content: string;
+  rating: number;
+};
+
+export type ReviewResponse = ReviewBase & {
+  user: User;
+  reviewImages: Image[];
+  isLiked: boolean;
+};
+
+export type PostReviewRes = ReviewResponse;
+export type PatchReviewRes = ReviewResponse;
+export type PostReviewLikeRes = ReviewResponse;
+export type DeleteReviewLikeRes = ReviewResponse;
+
+export type DeleteReviewRes = ReviewBase;

--- a/src/Apis/Review/queries.ts
+++ b/src/Apis/Review/queries.ts
@@ -1,0 +1,35 @@
+import ReviewService from './Review.service';
+import { PatchReview, PostReview } from './Review.type';
+
+const queryKeys = {
+  postReview: (params: PostReview) => ['postReview', params] as const,
+  deleteReview: (reviewId: number) => ['deleteReview', reviewId] as const,
+  postReviewLike: (reviewId: number) => ['postReviewLike', reviewId] as const,
+  deleteReviewLike: (reviewId: number) => ['deleteReviewLike', reviewId] as const,
+  patchReview: (reviewId: number, params: PatchReview) => ['patchReview', { reviewId, params }] as const,
+};
+
+const queryOptions = {
+  postReview: (params: PostReview) => ({
+    mutationKey: queryKeys.postReview(params),
+    mutationFn: () => ReviewService.postReview(params),
+  }),
+  deleteReview: (reviewId: number) => ({
+    mutationKey: queryKeys.deleteReview(reviewId),
+    mutationFn: () => ReviewService.deleteReview(reviewId),
+  }),
+  postReviewLike: (reviewId: number) => ({
+    mutationKey: queryKeys.postReviewLike(reviewId),
+    mutationFn: () => ReviewService.postReviewLike(reviewId),
+  }),
+  deleteReviewLike: (reviewId: number) => ({
+    mutationKey: queryKeys.deleteReviewLike(reviewId),
+    mutationFn: () => ReviewService.deleteReviewLike(reviewId),
+  }),
+  patchReview: (reviewId: number, params: PatchReview) => ({
+    mutationKey: queryKeys.patchReview(reviewId, params),
+    mutationFn: (patchData: PatchReview) => ReviewService.patchReview(reviewId, patchData),
+  }),
+};
+
+export default queryOptions;

--- a/src/Apis/Review/useReview.Service.ts
+++ b/src/Apis/Review/useReview.Service.ts
@@ -1,0 +1,67 @@
+import { useMutation } from '@tanstack/react-query';
+import queryOptions from './queries';
+import { selectData } from '../Utils';
+import {
+  DeleteReviewLikeRes,
+  DeleteReviewRes,
+  PatchReview,
+  PatchReviewRes,
+  PostReview,
+  PostReviewLikeRes,
+  PostReviewRes,
+} from './Review.type';
+
+/**
+ * 리뷰 생성
+ * @param params required; \{
+  productId: number;
+  images: string[];
+  content: string;
+  rating: number;
+}
+ */
+export function usePostReview(params: PostReview) {
+  const res = useMutation(queryOptions.postReview(params));
+  return selectData<PostReviewRes>(res);
+}
+
+/**
+ * 리뷰 삭제
+ * @param reviewId required number;
+ */
+export function useDeleteReview(reviewId: number) {
+  const res = useMutation(queryOptions.deleteReview(reviewId));
+  return selectData<DeleteReviewRes>(res);
+}
+
+/**
+ * 리뷰 좋아요
+ * @param reviewId require number;
+ */
+export function usePostReviewLike(reviewId: number) {
+  const res = useMutation(queryOptions.postReviewLike(reviewId));
+  return selectData<PostReviewLikeRes>(res);
+}
+
+/**
+ * 리뷰 좋아요 취소
+ * @param reviewId require number;
+ */
+export function useDeleteReviewLike(reviewId: number) {
+  const res = useMutation(queryOptions.deleteReviewLike(reviewId));
+  return selectData<DeleteReviewLikeRes>(res);
+}
+
+/**
+ * 리뷰 수정
+ * @param reviewId require number;
+ * @param params optional; \{
+  images: Image[];
+  content: string;
+  rating: number;
+}s
+ */
+export function usePatchReview(reviewId: number, params: PatchReview) {
+  const res = useMutation(queryOptions.patchReview(reviewId, params));
+  return selectData<PatchReviewRes>(res);
+}

--- a/src/Apis/User/User.service.ts
+++ b/src/Apis/User/User.service.ts
@@ -1,0 +1,54 @@
+/* eslint-disable class-methods-use-this */
+
+import { AxiosRequestConfig } from 'axios';
+import { apiRequestor, apiRequestorToken } from '../requestor';
+import { PatchUserProps, UserId } from './User.type';
+import { BaseQuery } from '../common.type';
+
+class UserService {
+  getUserMe(params: BaseQuery) {
+    const config: AxiosRequestConfig = { params };
+    return apiRequestorToken.get(`/users/me`, config);
+  }
+
+  patchUserMe(payload: PatchUserProps) {
+    return apiRequestorToken.patch(`/users/me`, payload);
+  }
+
+  getUserRanking(params: BaseQuery) {
+    const config: AxiosRequestConfig = { params };
+    return apiRequestor.get(`/users/ranking`, config);
+  }
+
+  getUserInfo(userID: UserId, params: BaseQuery) {
+    const config: AxiosRequestConfig = { params };
+    return apiRequestor.get(`/users/${userID}`, config);
+  }
+
+  getUserCreatedProduct(userID: UserId, params: BaseQuery) {
+    const config: AxiosRequestConfig = { params };
+    return apiRequestor.get(`/users/${userID}/created-products`, config);
+  }
+
+  getUserReviewedProduct(userID: UserId, params: BaseQuery) {
+    const config: AxiosRequestConfig = { params };
+    return apiRequestor.get(`/users/${userID}/reviewed-products`, config);
+  }
+
+  getUserFavoriteProduct(userID: UserId, params: BaseQuery) {
+    const config: AxiosRequestConfig = { params };
+    return apiRequestor.get(`/users/${userID}/favorite-products`, config);
+  }
+
+  getUserFollowees(userID: UserId, params: BaseQuery) {
+    const config: AxiosRequestConfig = { params };
+    return apiRequestor.get(`/users/${userID}/followees`, config);
+  }
+
+  getUserFollowers(userID: UserId, params: BaseQuery) {
+    const config: AxiosRequestConfig = { params };
+    return apiRequestor.get(`/users/${userID}/followers`, config);
+  }
+}
+
+export default new UserService();

--- a/src/Apis/User/User.type.ts
+++ b/src/Apis/User/User.type.ts
@@ -1,0 +1,73 @@
+export type PatchUserProps = {
+  description: string;
+  nickname: string;
+  image: string | null;
+};
+export type UserId = {
+  userId: number;
+};
+export type RankingInfo = {
+  id: number;
+  nickname: string;
+  description: string;
+  image: string | null;
+  createdAt: string;
+  updatedAt: string;
+  teamId: string;
+  followersCount: number;
+  reviewCount: number;
+};
+export type GetUserRanking = RankingInfo[];
+export type UserInformationRes = {
+  id: number;
+  nickname: string;
+  description: string;
+  image?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  teamId: number;
+  isFollowing: boolean;
+  followersCount: number;
+  followeesCount: number;
+  reviewCount: number;
+  averageRating: number;
+  mostFavoriteCategory?: string;
+};
+export type PatchUserMeRes = {
+  id: number;
+  nickname: string;
+  description: string;
+  image: string | null;
+  createdAt: string;
+  updatedAt: string;
+  teamId: number;
+};
+export type Follow = {
+  updatedAt: Date;
+  createdAt: Date;
+  teamId: string;
+  image: string | null;
+  description: string;
+  nickname: string;
+  id: number;
+};
+export type GetUserFollow = {
+  list: Follow[];
+  nextCursor: null;
+};
+export type Product = {
+  updatedAt: Date;
+  createdAt: Date;
+  writerId: number;
+  categoryId: number;
+  favoriteCount: number;
+  reviewCount: number;
+  rating: number;
+  image: string | null;
+  name: string;
+  id: number;
+};
+export type GetProduct = {
+  nextCursor: number;
+  list: Product[];
+};

--- a/src/Apis/User/queries.ts
+++ b/src/Apis/User/queries.ts
@@ -1,0 +1,58 @@
+import { BaseQuery } from '../common.type';
+import UserService from './User.service';
+import { PatchUserProps, UserId } from './User.type';
+
+const queryKeys = {
+  getUserMe: (params: BaseQuery) => ['getUserMe', params] as const,
+  patchUserMe: (payload: PatchUserProps) => ['patchUserMe', payload] as const,
+  getUserRanking: (params: BaseQuery) => ['getUserRanking', params] as const,
+  getUserInfo: (userId: UserId, params: BaseQuery) => ['getUserInfo', { userId, params }] as const,
+  getUserCreatedProduct: (userId: UserId, params: BaseQuery) => ['getUserCreatedProduct', { userId, params }] as const,
+  getUserReviewedProduct: (userId: UserId, params: BaseQuery) =>
+    ['getUserReviewedProduct', { userId, params }] as const,
+  getUserFavoriteProduct: (userId: UserId, params: BaseQuery) =>
+    ['getUserFavoriteProduct', { userId, params }] as const,
+  getUserFollowees: (userId: UserId, params: BaseQuery) => ['getUserFollowees', { userId, params }] as const,
+  getUserFollowers: (userId: UserId, params: BaseQuery) => ['getUserFollowers', { userId, params }] as const,
+};
+
+const queryOptions = {
+  getUserMe: (params: BaseQuery) => ({
+    queryKey: queryKeys.getUserMe(params),
+    queryFn: () => UserService.getUserMe(params),
+  }),
+  patchUserMe: (payload: PatchUserProps) => ({
+    mutationKey: queryKeys.patchUserMe(payload),
+    mutationFn: (patchPayload: PatchUserProps) => UserService.patchUserMe(patchPayload),
+  }),
+  getUserRanking: (params: BaseQuery) => ({
+    queryKey: queryKeys.getUserRanking(params),
+    queryFn: () => UserService.getUserRanking(params),
+  }),
+  getUserInfo: (userId: UserId, params: BaseQuery) => ({
+    queryKey: queryKeys.getUserInfo(userId, params),
+    queryFn: () => UserService.getUserInfo(userId, params),
+  }),
+  getUserCreatedProduct: (userId: UserId, params: BaseQuery) => ({
+    queryKey: queryKeys.getUserCreatedProduct(userId, params),
+    queryFn: () => UserService.getUserCreatedProduct(userId, params),
+  }),
+  getUserReviewedProduct: (userId: UserId, params: BaseQuery) => ({
+    queryKey: queryKeys.getUserReviewedProduct(userId, params),
+    queryFn: () => UserService.getUserReviewedProduct(userId, params),
+  }),
+  getUserFavoriteProduct: (userId: UserId, params: BaseQuery) => ({
+    queryKey: queryKeys.getUserFavoriteProduct(userId, params),
+    queryFn: () => UserService.getUserFavoriteProduct(userId, params),
+  }),
+  getUserFollowees: (userId: UserId, params: BaseQuery) => ({
+    queryKey: queryKeys.getUserFollowees(userId, params),
+    queryFn: () => UserService.getUserFollowees(userId, params),
+  }),
+  getUserFollowers: (userId: UserId, params: BaseQuery) => ({
+    queryKey: queryKeys.getUserFollowers(userId, params),
+    queryFn: () => UserService.getUserFollowers(userId, params),
+  }),
+};
+
+export default queryOptions;

--- a/src/Apis/User/useUserService.ts
+++ b/src/Apis/User/useUserService.ts
@@ -1,0 +1,132 @@
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import queryOptions from './queries';
+import { BaseQuery } from '../common.type';
+import {
+  GetProduct as GetProductRes,
+  GetUserFollow as GetUserFollowRes,
+  GetUserRanking as GetUserRankingRes,
+  PatchUserMeRes,
+  PatchUserProps,
+  UserId,
+  UserInformationRes,
+} from './User.type';
+import { selectData } from '../Utils';
+
+/**
+ * 특정 사용자의 정보를 조회합니다.
+ * @param params optional; \{
+  offset?: number;
+  limit?: number;
+}
+ */
+export function useGetUserMe(params: BaseQuery) {
+  const res = useSuspenseQuery(queryOptions.getUserMe(params));
+  return selectData<UserInformationRes>(res);
+}
+
+/**
+ * 내 정보를 수정합니다.
+ * @param payload required; {
+  description: string,
+  nickname: string,
+  image: string,
+}
+ * @returns \{
+  item: ItemInfo;
+  links: Array\<Link>;
+}
+ */
+export function usePatchUserMe(payload: PatchUserProps) {
+  const res = useMutation(queryOptions.patchUserMe(payload));
+  return selectData<PatchUserMeRes>(res);
+}
+
+/**
+ * 유저 랭킹 조회
+ * @param params optional; \{
+  offset?: number;
+  limit?: number;
+}
+ */
+export function useGetUserRanking(params: BaseQuery) {
+  const res = useSuspenseQuery(queryOptions.getUserRanking(params));
+  return selectData<GetUserRankingRes>(res);
+}
+
+/**
+ * 유저 정보 조회
+ * @param userId require; \{userId: number}
+ * @param params optional; \{
+  offset?: number;
+  limit?: number;
+}
+ */
+export function useGetUserInfo(userId: UserId, params: BaseQuery) {
+  const res = useSuspenseQuery(queryOptions.getUserInfo(userId, params));
+  return selectData<UserInformationRes>(res);
+}
+
+/**
+ * 유저가 생성한 상품 조회
+ * @param userId require;  \{userId: number}
+ * @param params optional; \{
+  offset?: number;
+  limit?: number;
+}
+ */
+export function useGetUserCreatedProduct(userId: UserId, params: BaseQuery) {
+  const res = useSuspenseQuery(queryOptions.getUserCreatedProduct(userId, params));
+  return selectData<GetProductRes>(res);
+}
+
+/**
+ * 유저가 찜한 상품 조회
+ * @param userId require; \{userId: number}
+ * @param params optional; \{
+  offset?: number;
+  limit?: number;
+}
+ */
+export function useGetUserReviewedProduct(userId: UserId, params: BaseQuery) {
+  const res = useSuspenseQuery(queryOptions.getUserReviewedProduct(userId, params));
+  return selectData<GetProductRes>(res);
+}
+
+/**
+ * 유저가 찜한 상품 조회
+ * @param userId require; \{userId: number}
+ * @param params optional; \{
+  offset?: number;
+  limit?: number;
+}
+ */
+export function useGetUserFavoriteProduct(userId: UserId, params: BaseQuery) {
+  const res = useSuspenseQuery(queryOptions.getUserFavoriteProduct(userId, params));
+  return selectData<GetProductRes>(res);
+}
+
+/**
+ * 유저가 팔로우한 유저 조회(팔로잉)
+ * @param userId require; \{userId: number}
+ * @param params optional; \{
+  offset?: number;
+  limit?: number;
+}
+ */
+export function useGetUserFollowees(userId: UserId, params: BaseQuery) {
+  const res = useSuspenseQuery(queryOptions.getUserFollowees(userId, params));
+  return selectData<GetUserFollowRes>(res);
+}
+
+/**
+ * 유저를 팔로우한 유저 조회(팔로워)
+ * @param userId require; \{userId: number}
+ * @param params optional; \{
+  offset?: number;
+  limit?: number;
+}
+ */
+export function useGetUserFollowers(userId: UserId, params: BaseQuery) {
+  const res = useSuspenseQuery(queryOptions.getUserFollowers(userId, params));
+  return selectData<GetUserFollowRes>(res);
+}

--- a/src/Apis/common.type.ts
+++ b/src/Apis/common.type.ts
@@ -2,6 +2,3 @@ export type BaseQuery = {
   offset?: number;
   limit?: number;
 };
-/**
- * @TODO 각 타입들에서 공용타입으로 빼기
- */


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) #11 
- 이제 api 작업이 가능합니다~~
- Apis 폴더 안에 스웨거 문서와 동일하게 폴더 정리 되어 있습니다.
- 그 안에서 훅 가져다 쓰시면 됩니다! (오류 많음..!) => 말씀해주시면 바로 고칠게요

## 📝작업 내용
- 데쟈뷰 느낀다면 맞습니다 저번에 User일부, Category, Auth, Follow api셋팅 했고
-  이번이 Product, Review, User나머지, Image 관련 셋팅 완료했습니다

## 참고
- 이론상 동작 할 것이 확실하나, 모두 테스트하지는 못했습니다.
   (테스트케이스 너무많아욥..)
  => 그래서 무슨말이 하고싶은건데?
  => 오류를 필연적으로 마주 할 것입니다...죄송 ㅎ

##해야 할 것
- Oauth (얜 아직 못함..)
- 간편로그인(auth)
- 타입 더 수정해야함.
