### PR TITLE
28 feat 비교하기 화면

### DIFF
--- a/src/Apis/server.requestor.ts
+++ b/src/Apis/server.requestor.ts
@@ -7,7 +7,7 @@
 import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 
 const axiosRequestConfig: AxiosRequestConfig = {
-  baseURL: 'https://mogazoa-api.vercel.app/4-18/',
+  baseURL: `${process.env.NEXT_PUBLIC_API_BASE_URL}`,
   responseType: 'json',
   headers: {
     'Content-Type': 'application/json',

--- a/src/Components/Compare/Compare.tsx
+++ b/src/Components/Compare/Compare.tsx
@@ -78,11 +78,13 @@ function CompareComponent({ compareFirst, compareSecond }: Props) {
   }, [compareFirst, compareSecond, params]);
 
   return (
-    <main className="pt-[3.75rem]">
+    <main className="pt-[1.88rem] md:pt-[2.5rem] lg:pt-[3.75rem]">
       <section className="mx-auto flex flex-col w-fit">
-        <article className="flex gap-5 items-end">
+        <article className="flex-col md:flex-row flex gap-[1.88rem] md:gap-5 items-end">
           <div className="flex flex-col gap-[0.62rem]">
-            <label className='text-[#F1F1F5] font-["Pretendard"] text-base font-normal leading-[normal]'>상품1</label>
+            <strong className='text-[#F1F1F5] font-["Pretendard"] text-sm lg:text-base font-normal leading-[normal]'>
+              상품1
+            </strong>
             <DropdownSearch
               option={option}
               value={selectOption1}
@@ -95,7 +97,9 @@ function CompareComponent({ compareFirst, compareSecond }: Props) {
             />
           </div>
           <div className="flex flex-col gap-[0.62rem]">
-            <label className='text-[#F1F1F5] font-["Pretendard"] text-base font-normal leading-[normal]'>상품2</label>
+            <strong className='text-[#F1F1F5] font-["Pretendard"] text-sm lg:text-base font-normal leading-[normal]'>
+              상품2
+            </strong>
             <DropdownSearch
               option={option}
               value={selectOption2}
@@ -109,7 +113,7 @@ function CompareComponent({ compareFirst, compareSecond }: Props) {
           </div>
           <Button
             color="primary"
-            className="w-[12.5rem] h-[4.375rem] flex items-center justify-center font-base font-normal leading-[normal] px-0 py-0"
+            className="w-[20.9375rem] md:w-[10.25rem] lg:w-[12.5rem] h-[3.175rem] md:h-[3.4375rem] lg:h-[4.375rem] flex items-center justify-center font-base font-normal leading-[normal] !px-0 !py-0"
             disabled={!(selectOption1 && selectOption2)}
             onClick={() => {
               if (selectOption1 && selectOption2) {
@@ -122,36 +126,38 @@ function CompareComponent({ compareFirst, compareSecond }: Props) {
         </article>
         <article className="w-full flex items-center justify-center">
           {params.getData('compare1') && params.getData('compare2') ? (
-            <div className="w-full h-[51.315rem] pt-[8.75rem] pb-[14.75rem] flex flex-col items-center">
-              <strong className="text-2xl laeding-[normal] font-semibold text-[#F1F1F5]">
+            <div className="w-full h-[34.25rem] md:h-[51.315rem] pt-[6.25rem] md:pt-[8.75rem] md:pb-[14.75rem] flex flex-col items-center">
+              <div className="text-xl lg:text-2xl laeding-[normal] font-semibold text-[#F1F1F5] text-center">
                 {compareState > 0 && (
                   <div className="flex flex-col gap-5 items-center">
-                    <span className="flex gap-2">
-                      <p className="text-[#05D58B]">
-                        {option.find((op) => op.value === Number(params.get('compare1')))?.label}
-                      </p>
-                      상품이 승리하였습니다!
-                    </span>
-                    <p className="text-base font-normal leading-normal text-[#9FA6B2]">
+                    <div>
+                      <span className="text-[#05D58B]">
+                        {`${option.find((op) => op.value === Number(params.get('compare1')))?.label} `}
+                      </span>
+                      상품이 <br className="block lg:hidden" />
+                      승리하였습니다!
+                    </div>
+                    <p className="text-xs lg:text-base font-normal leading-normal text-[#9FA6B2]">
                       3가지 항목 중 {Math.abs(compareState) + 1}가지 항목에서 우세합니다.
                     </p>
                   </div>
                 )}
                 {compareState < 0 && (
                   <div className="flex flex-col gap-5 items-center">
-                    <span className="flex gap-2">
-                      <p className="text-[#FF2F9F]">
-                        {option.find((op) => op.value === Number(params.get('compare2')))?.label}
-                      </p>
-                      상품이 승리하였습니다!
-                    </span>
-                    <p className="text-base font-normal leading-normal text-[#9FA6B2]">
+                    <div>
+                      <span className="text-[#FF2F9F]">
+                        {`${option.find((op) => op.value === Number(params.get('compare2')))?.label} `}
+                      </span>
+                      상품이
+                      <br className="block lg:hidden" /> 승리하였습니다!
+                    </div>
+                    <p className="text-xs lg:text-base font-normal leading-normal text-[#9FA6B2]">
                       3가지 항목 중 {Math.abs(compareState) + 1}가지 항목에서 우세합니다.
                     </p>
                   </div>
                 )}
                 {compareState === 0 && <span>무승부입니다.</span>}
-              </strong>
+              </div>
               <CompareTable compareFirst={compareFirst} compareSecond={compareSecond} />
             </div>
           ) : (

--- a/src/Components/Compare/CompareTable.tsx
+++ b/src/Components/Compare/CompareTable.tsx
@@ -21,19 +21,22 @@ const COMPARE_LIST = [
  */
 function CompareTable({ compareFirst, compareSecond }: Props) {
   return (
-    <div className="w-full h-[18.5625rem] mt-20 bg-[#252530] border-2 border-[#353542] rounded-xl">
-      <div className="h-[3.75rem] border-b-2 border-[#353542] grid grid-cols-4 content-center justify-items-center text-[#9FA6B2] text-base font-normal leading-normal">
+    <div className="w-full h-[11.625rem] md:h-[18.5625rem] mt-10 md:mt-20 bg-[#252530] border-2 border-[#353542] rounded-xl">
+      <div className="h-[2.75rem] md:h-[3.75rem] border-b-2 border-[#353542] grid grid-cols-4 content-center justify-items-center text-[#9FA6B2] text-sm lg:text-base font-normal leading-normal">
         <p>기준</p>
         <p>상품1</p>
         <p>상품2</p>
         <p>결과</p>
       </div>
-      <div className="grid grid-rows-3 text-[#9FA6B2] text-base font-normal leading-normal">
+      <div className="grid grid-rows-3 text-[#9FA6B2] text-sm lg:text-base font-normal leading-normal">
         {COMPARE_LIST.map((compare: any) => {
           const first = compareFirst?.[compare.dataIndex as 'rating' | 'reviewCount' | 'favoriteCount'] ?? 0;
           const second = compareSecond?.[compare.dataIndex as 'rating' | 'reviewCount' | 'favoriteCount'] ?? 0;
           return (
-            <div key={compare.dataIndex} className="h-[5rem] grid grid-cols-4 content-center justify-items-center">
+            <div
+              key={compare.dataIndex}
+              className="h-[2.96rem] md:h-[5rem] grid grid-cols-4 content-center justify-items-center"
+            >
               <p>{compare.label}</p>
               <p className="text-white">{first}</p>
               <p className="text-white">{second}</p>

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -15,8 +15,10 @@ async function ComparePage({ searchParams }: Props) {
   let compare2: { data?: ProductDetail } = {};
 
   if (searchParams?.compare1 && searchParams?.compare2) {
-    compare1 = await apiRequestor.get(`/products/${searchParams?.compare1 ? Number(searchParams?.compare1) : 0}`);
-    compare2 = await apiRequestor.get(`/products/${searchParams?.compare2 ? Number(searchParams?.compare2) : 0}`);
+    [compare1, compare2] = await Promise.all([
+      apiRequestor.get(`/products/${searchParams?.compare1 ? Number(searchParams?.compare1) : 0}`),
+      apiRequestor.get(`/products/${searchParams?.compare2 ? Number(searchParams?.compare2) : 0}`),
+    ]);
   }
 
   return (


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #28 

## 📝작업 내용

> 비교하기 페이지 반응형 작업했습니다.
멘토님 지적사항 중 비동기 직렬 수정했습니다.

> 지금보니 우세 카운트가 틀렸네요.. 수정하겠습니다

### 스크린샷 (선택)
- 모바일
<img width="440" alt="스크린샷 2024-06-09 오후 9 37 49" src="https://github.com/Team18-Mogazoa/MOGAZOA/assets/155204900/0747f28b-df31-4944-b42b-eb928b810951">

- 태블릿
<img width="809" alt="스크린샷 2024-06-09 오후 9 38 07" src="https://github.com/Team18-Mogazoa/MOGAZOA/assets/155204900/d5918143-6836-4bf5-8d03-e4ef585e1149">

- PC
<img width="1002" alt="스크린샷 2024-06-09 오후 9 38 26" src="https://github.com/Team18-Mogazoa/MOGAZOA/assets/155204900/832269b4-8bf9-4d37-a3dd-b7638804d6b2">

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
