### PR TITLE
Fix: 비교하기 무한스크롤 추가

### DIFF
--- a/src/Components/Commons/Dropdown/DropdownComponent.tsx
+++ b/src/Components/Commons/Dropdown/DropdownComponent.tsx
@@ -31,9 +31,10 @@ interface SearchProps extends Props {
    * search(default) - 검색이 가능한 기본 Dropdown
    */
   type?: 'tag_first' | 'tag_second' | 'search';
+  target: any;
 }
 
-export function DropdownSearch({ option, value, onChange, type = 'search' }: SearchProps) {
+export function DropdownSearch({ option, value, onChange, target, type = 'search' }: SearchProps) {
   // dropdown hook
   const { btnRef, isOpen, clickHandler } = useDropdown();
   // 검색 input value state
@@ -75,9 +76,9 @@ export function DropdownSearch({ option, value, onChange, type = 'search' }: Sea
    */
   const optionList = useMemo(() => {
     // 검색 후 뿌려주기 (filter)
-    const searchFilter = option.filter((e) => e.label.includes(search));
+    const searchFilter = option?.filter((e) => e.label.includes(search));
 
-    return searchFilter.length > 0 ? (
+    return searchFilter?.length > 0 ? (
       searchFilter.map((e) => (
         <button
           key={e.value}
@@ -147,9 +148,10 @@ export function DropdownSearch({ option, value, onChange, type = 'search' }: Sea
         <div className="relative">
           <div className="absolute top-2">
             <div
-              className={`${widthSize} state_menu__size_l flex flex-col items-start p-2 rounded-lg border border-[#353542] bg-[#252530]`}
+              className={`${widthSize} max-h-[200px] overflow-auto state_menu__size_l flex flex-col items-start p-2 rounded-lg border border-[#353542] bg-[#252530]`}
             >
               {optionList}
+              <div className="h-[1px]" ref={target}></div>
             </div>
           </div>
         </div>

--- a/src/Hooks/useInfinityRequest.ts
+++ b/src/Hooks/useInfinityRequest.ts
@@ -1,0 +1,39 @@
+import { apiRequestor } from '@/Apis/requestor';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useIntersectionObserver } from './useIntersectionObserver';
+
+interface requestType {
+  queryKey: string | string[];
+  requestParam: Record<string, any>;
+  requestPath: string;
+  method: string;
+}
+
+export const useInfinityRequest = ({ queryKey, requestParam, requestPath, method }: requestType) => {
+  const { data, isLoading, fetchNextPage, hasNextPage } = useInfiniteQuery({
+    queryKey: typeof queryKey === 'string' ? [queryKey] : queryKey,
+    queryFn: ({ pageParam }: { pageParam: any }) => {
+      let path = requestPath;
+      let apiBody = requestParam;
+      if (method === 'GET' && pageParam) {
+        const searchParam = new URLSearchParams({ ...apiBody, cursor: pageParam });
+        path = requestPath + '?' + searchParam.toString();
+      }
+      return apiRequestor({
+        method,
+        url: path,
+        data: pageParam ? { ...apiBody, cursor: pageParam } : { ...apiBody },
+      });
+    },
+    getNextPageParam: (lastPage: any) => {
+      return lastPage?.data?.nextCursor;
+    },
+  });
+
+  const { setTarget } = useIntersectionObserver({
+    hasNextPage,
+    fetchNextPage,
+  });
+
+  return { data, isLoading, fetchNextPage, setTarget };
+};

--- a/src/Hooks/useIntersectionObserver.ts
+++ b/src/Hooks/useIntersectionObserver.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+
+export const useIntersectionObserver = ({ threshold = 0.1, hasNextPage, fetchNextPage }: any) => {
+  //관찰할 요소입니다. 스크롤 최하단 div요소에 setTarget을 ref로 넣어 사용할 것입니다.
+  const [target, setTarget] = useState();
+
+  const observerCallback = (entries: any[]) => {
+    entries.forEach((entry: { isIntersecting: any }) => {
+      //target이 화면에 관찰되고, 다음페이지가 있다면 다음페이지를 호출
+      if (entry.isIntersecting && hasNextPage) {
+        fetchNextPage();
+      }
+    });
+  };
+
+  useEffect(() => {
+    if (!target) return;
+
+    //ointersection observer 인스턴스 생성
+    const observer = new IntersectionObserver(observerCallback, {
+      threshold,
+    });
+
+    // 타겟 관찰 시작
+    observer.observe(target);
+
+    // 관찰 멈춤
+    return () => observer.unobserve(target);
+  }, [observerCallback, threshold, target]);
+
+  return { setTarget };
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 비교하기 페이지 상품 목록 무한스크롤 기능 추가했습니다.
> useInfinityRequest, useIntersectionObserver hook 추가했습니다.


- 사용법
```js
  // useInfinityRequest hook 호출
  // data > request data
  // fetchNextPage > 초기 api 호출 시 사용
  // setTarget > 스크롤 마지막 영역(div)의 ref에 등록
  const { data, fetchNextPage, setTarget } = useInfinityRequest({
    queryKey: ['products'],
    requestParam: {},
    requestPath: '/products',
    method: 'GET',
  });

  useEffect(() => {
    // 초기 호출 시 사용
    fetchNextPage();
  },[]}
  
  // 호출 한 데이터의 page를 전부 flat 처리 하여 list로 활용
  const productList = useMemo(() => {
    return data?.pages?.map((page: Record<string, any>) => page.data.list).flat();
  }, [data]);


...

return (
  <>
 ...
{/* 리스트의 마지막에 1px짜리 ref를 등록할 수 있는 영역 선언 */}
     <div className="h-[1px]" ref={setTarget}></div>
  </>
)
```
비교하기 페이지에서 확인 가능합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
